### PR TITLE
feat(backend): adicionar endpoints de agendamento para cliente

### DIFF
--- a/backend/src/controllers/client-controller.ts
+++ b/backend/src/controllers/client-controller.ts
@@ -38,4 +38,34 @@ const getRecipes = asyncHandler(async (req) => {
   return clientService.listRecipesByClient(req.user?.cpf);
 });
 
-export { getAppointments, getProfile, updateProfile, getRecipes };
+const createAppointment = asyncHandler(async (req) => {
+  return clientService.createAppointment(req.user?.cpf, req.body);
+}, 201);
+
+const getClientPets = asyncHandler(async (req) => {
+  return clientService.listClientPets(req.user?.cpf);
+});
+
+const getSpecialties = asyncHandler(async (_req) => {
+  return clientService.listSpecialties();
+});
+
+const getDoctors = asyncHandler(async (req) => {
+  return clientService.listDoctors(req.query.specialty_id as string | undefined);
+});
+
+const getDoctorAvailability = asyncHandler(async (req) => {
+  return clientService.getDoctorAvailability(req.params.doctorId);
+});
+
+export {
+  getAppointments,
+  getProfile,
+  updateProfile,
+  getRecipes,
+  createAppointment,
+  getClientPets,
+  getSpecialties,
+  getDoctors,
+  getDoctorAvailability,
+};

--- a/backend/src/models/appointment-model.ts
+++ b/backend/src/models/appointment-model.ts
@@ -51,4 +51,51 @@ async function findAllAppointments() {
   });
 }
 
-export { findAppointmentsByClientCpf, findAllAppointments };
+export type NewAppointmentData = {
+  pet_id: string;
+  appointment_date: Date | string;
+  doctor_id: string;
+  specialty_id: string;
+};
+
+async function createAppointment(
+  data: NewAppointmentData
+): Promise<AppointmentRowForClient> {
+  const row = await prisma.appointment.create({
+    data: {
+      pet_id: data.pet_id,
+      appointment_date: data.appointment_date,
+      doctor_id: data.doctor_id,
+      specialty_id: data.specialty_id,
+    },
+    include: {
+      pet: { select: { pet_id: true, name: true } },
+      doctor: { select: { name: true } },
+      specialty: { select: { name: true } },
+    },
+  });
+
+  return {
+    appointment_id: row.appointment_id,
+    appointment_date: row.appointment_date,
+    pet_id: row.pet_id,
+    pet_name: row.pet?.name ?? null,
+    doctor_name: row.doctor?.name ?? null,
+    specialty_name: row.specialty?.name ?? null,
+  };
+}
+
+async function findBookedDatesByDoctor(doctorId: string): Promise<Date[]> {
+  const rows = await prisma.appointment.findMany({
+    where: { doctor_id: doctorId, deleted_at: null },
+    select: { appointment_date: true },
+  });
+  return rows.map((r) => r.appointment_date);
+}
+
+export {
+  findAppointmentsByClientCpf,
+  findAllAppointments,
+  createAppointment,
+  findBookedDatesByDoctor,
+};

--- a/backend/src/models/doctor-model.ts
+++ b/backend/src/models/doctor-model.ts
@@ -94,9 +94,22 @@ async function softDeleteDoctor(
   return { doctor_id: doctorId };
 }
 
+async function findDoctorsBySpecialtyId(
+  specialtyId: string
+): Promise<DoctorListRow[]> {
+  return prisma.doctor.findMany({
+    where: { deleted_at: null, specialty_id: specialtyId },
+    orderBy: { name: "asc" },
+    include: {
+      specialty: { select: specialtySelect },
+    },
+  });
+}
+
 export {
   findAllDoctors,
   findDoctorById,
+  findDoctorsBySpecialtyId,
   createDoctor,
   updateDoctor,
   softDeleteDoctor,

--- a/backend/src/routes/client-routes.ts
+++ b/backend/src/routes/client-routes.ts
@@ -6,6 +6,11 @@ import {
   getProfile,
   updateProfile,
   getRecipes,
+  createAppointment,
+  getClientPets,
+  getSpecialties,
+  getDoctors,
+  getDoctorAvailability,
 } from "@/controllers/client-controller.ts";
 
 const router = express.Router();
@@ -13,7 +18,12 @@ const router = express.Router();
 router.use(authMiddleware, requireClient);
 router.get("/profile", getProfile);
 router.put("/profile", updateProfile);
+router.get("/pets", getClientPets);
+router.get("/specialties", getSpecialties);
+router.get("/doctors", getDoctors);
+router.get("/doctors/:doctorId/availability", getDoctorAvailability);
 router.get("/appointments", getAppointments);
+router.post("/appointments", createAppointment);
 router.get("/recipes", getRecipes);
 
 export default router;

--- a/backend/src/services/client-service.ts
+++ b/backend/src/services/client-service.ts
@@ -1,7 +1,10 @@
 import bcrypt from "bcrypt";
+import prisma from "@/prisma-client.ts";
 import * as appointmentModel from "@/models/appointment-model.ts";
 import * as clientModel from "@/models/client-model.ts";
 import * as recipeModel from "@/models/recipe-model.ts";
+import * as doctorModel from "@/models/doctor-model.ts";
+import * as specialtyModel from "@/models/specialty-model.ts";
 import { AppError } from "@/services/auth-service.ts";
 
 async function listAppointmentsByClient(cpf: string | undefined) {
@@ -67,9 +70,94 @@ async function listRecipesByClient(cpf: string | undefined) {
   return recipeModel.findRecipesByClientCpf(cpf);
 }
 
+async function createAppointment(
+  cpf: string | undefined,
+  body: {
+    pet_id?: string;
+    appointment_date?: string;
+    doctor_id?: string;
+    specialty_id?: string;
+  }
+) {
+  if (!cpf) {
+    throw new AppError("CPF não informado no token", 401);
+  }
+
+  const { pet_id, appointment_date, doctor_id, specialty_id } = body ?? {};
+
+  if (!pet_id || !appointment_date || !doctor_id || !specialty_id) {
+    throw new AppError(
+      "Os campos pet_id, appointment_date, doctor_id e specialty_id são obrigatórios.",
+      400
+    );
+  }
+
+  const date = new Date(appointment_date);
+  if (isNaN(date.getTime())) {
+    throw new AppError("appointment_date inválida.", 400);
+  }
+  if (date <= new Date()) {
+    throw new AppError("A data do agendamento deve ser futura.", 400);
+  }
+
+  const pet = await prisma.pet.findFirst({
+    where: { pet_id, client_cpf: cpf, deleted_at: null },
+  });
+  if (!pet) {
+    throw new AppError("Pet não encontrado ou não pertence a este cliente.", 403);
+  }
+
+  return appointmentModel.createAppointment({
+    pet_id,
+    appointment_date: date,
+    doctor_id,
+    specialty_id,
+  });
+}
+
+async function listClientPets(cpf: string | undefined) {
+  if (!cpf) {
+    throw new AppError("CPF não informado no token", 401);
+  }
+
+  return prisma.pet.findMany({
+    where: { client_cpf: cpf, deleted_at: null },
+    select: { pet_id: true, name: true },
+    orderBy: { name: "asc" },
+  });
+}
+
+async function listSpecialties() {
+  return specialtyModel.findAllSpecialties();
+}
+
+async function listDoctors(specialtyId?: string) {
+  if (specialtyId) {
+    return doctorModel.findDoctorsBySpecialtyId(specialtyId);
+  }
+  return doctorModel.findAllDoctors();
+}
+
+async function getDoctorAvailability(doctorId: string | undefined) {
+  if (!doctorId) {
+    throw new AppError("doctorId não informado", 400);
+  }
+
+  const booked = await appointmentModel.findBookedDatesByDoctor(doctorId);
+
+  return {
+    booked_dates: booked.map((d) => d.toISOString()),
+  };
+}
+
 export {
   listAppointmentsByClient,
   getClientProfile,
   updateClientProfile,
   listRecipesByClient,
+  createAppointment,
+  listClientPets,
+  listSpecialties,
+  listDoctors,
+  getDoctorAvailability,
 };


### PR DESCRIPTION
- POST /client/appointments: criar agendamento com validacoes de CPF, campos obrigatorios, data futura e ownership do pet
- GET /client/pets: listar pets do cliente autenticado
- GET /client/specialties: listar todas as especialidades
- GET /client/doctors: listar doutores com filtro opcional por specialty_id
- GET /client/doctors/:id/availability: retornar datas ja ocupadas do doutor
- Adiciona findDoctorsBySpecialtyId em doctor-model
- Adiciona findBookedDatesByDoctor em appointment-model